### PR TITLE
2 add alternative gravity implementation

### DIFF
--- a/gravitas/Scripts/Gravity.gd
+++ b/gravitas/Scripts/Gravity.gd
@@ -1,0 +1,85 @@
+extends Node
+
+# Global Gravity variables
+var mode = "scene"
+var player: CharacterBody2D
+var isRotating = false
+var currentGravityDirection = SOUTH
+var currentGravity: Vector2 = GRAVITY_SOUTH
+
+# Constants and states for rotateScene function
+const RIGHT_ANGLE = 90
+const ROTATION_DELTA = 3
+var isTurningRight = false
+var isTurningLeft = false
+var rotation_state = 0.0
+
+# Constants and states for rotatePlayer function
+const SOUTH = 0
+const EAST = 1
+const NORTH = 2
+const WEST = 3
+const GRAVITY_SOUTH = Vector2(0, 980) # Normal gravity
+const GRAVITY_EAST = Vector2(980, 0) # Player falls to east
+const GRAVITY_NORTH = Vector2(0, -980) # Player falls to north
+const GRAVITY_WEST = Vector2(-980, 0) # Player falls to west
+
+func rotate() -> void:
+	if mode == "scene":
+		rotateScene()
+	elif mode == "player":
+		rotatePlayer()
+
+func rotateScene() -> void:
+	# TODO: make it possible to change direction in the middle of rotation
+	# TODO: put velocity.x to 0 when on floor
+
+	var currentScene = get_tree().get_current_scene()
+	
+	if isTurningRight:
+		var currentRotation = currentScene.get_rotation_degrees()
+		if RIGHT_ANGLE > rotation_state:
+			currentScene.set_rotation_degrees(currentRotation + ROTATION_DELTA)
+			player.set_rotation_degrees(player.rotation_degrees - ROTATION_DELTA)
+			rotation_state += ROTATION_DELTA
+		else:
+			isTurningRight = false
+			rotation_state = 0
+		return
+		
+	if isTurningLeft:
+		var currentRotation = currentScene.get_rotation_degrees()
+		if RIGHT_ANGLE > rotation_state:
+			currentScene.set_rotation_degrees(currentRotation - ROTATION_DELTA)
+			player.set_rotation_degrees(player.rotation_degrees + ROTATION_DELTA)
+			rotation_state += ROTATION_DELTA
+		else:
+			isTurningLeft = false
+			rotation_state = 0
+		return
+
+	if Input.is_action_just_pressed("ui_down"):
+		isRotating = true
+		isTurningRight = true
+
+	if Input.is_action_just_pressed("ui_up"):
+		isRotating = true
+		isTurningLeft = true
+	
+
+func rotatePlayer() -> void:
+	if Input.is_action_just_pressed("ui_down"):
+		currentGravity = Vector2(currentGravity.y, -currentGravity.x)
+		currentGravityDirection = (currentGravityDirection + 1) % 4
+		
+		var currentUpDirection = player.get_up_direction()
+		player.set_up_direction(Vector2(currentUpDirection.y, -currentUpDirection.x))
+		player.set_rotation_degrees(player.get_rotation_degrees() - 90)
+
+	if Input.is_action_just_pressed("ui_up"):
+		currentGravity = Vector2(-currentGravity.y, currentGravity.x)
+		currentGravityDirection = (currentGravityDirection - 1) % 4
+		
+		var currentUpDirection = player.get_up_direction()
+		player.set_up_direction(Vector2(-currentUpDirection.y, currentUpDirection.x))
+		player.set_rotation_degrees(player.get_rotation_degrees() + 90)

--- a/gravitas/project.godot
+++ b/gravitas/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.3", "Mobile")
 config/icon="res://icon.svg"
 
+[autoload]
+
+Gravity="*res://Scripts/Gravity.gd"
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0

--- a/gravitas/scenes/player.gd
+++ b/gravitas/scenes/player.gd
@@ -1,19 +1,35 @@
 extends CharacterBody2D
 
-
 const SPEED = 300.0
 const JUMP_VELOCITY = -400.0
+const NULL_VECTOR = Vector2(0, 0)
 
+
+func _ready() -> void:
+	Gravity.player = self
 
 func _physics_process(delta: float) -> void:
+	# TODO: check if on floor and put speed to 0 instead of the current implementation
 	# Add the gravity.
 	if not is_on_floor():
-		velocity += get_gravity() * delta
+		velocity += Gravity.currentGravity * delta
+	
+	if is_on_floor_only():
+		# velocity.x = 0
+		pass
 
 	# Handle jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
-		velocity.y = JUMP_VELOCITY
+		velocity -= Gravity.currentGravity * 0.5
+	
+	move_and_slide()
+	
+	if Gravity.isRotating:
+		Gravity.rotate()
 
+	if Input.is_action_just_pressed("ui_down") or Input.is_action_just_pressed("ui_up"):
+		Gravity.rotate()
+	
 	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.
 	#var direction := Input.get_axis("ui_left", "ui_right")
@@ -21,5 +37,3 @@ func _physics_process(delta: float) -> void:
 	#	velocity.x = direction * SPEED
 	#else:
 	#	velocity.x = move_toward(velocity.x, 0, SPEED)
-
-	move_and_slide()

--- a/gravitas/scenes/player.tscn
+++ b/gravitas/scenes/player.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=12 format=3 uid="uid://cat83wdqdyhlq"]
 
 [ext_resource type="Script" path="res://scenes/player.gd" id="1_b1beh"]
-[ext_resource type="Texture2D" uid="uid://dyp2ne5f0feqy" path="res://Assets/Gravitas_assets/CosmicLilac_AnimatedSpriteSheet.png" id="1_dakvx"]
+[ext_resource type="Texture2D" uid="uid://mi2ws1kehiqm" path="res://Assets/Gravitas_assets/CosmicLilac_AnimatedSpriteSheet.png" id="1_dakvx"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_2ho7e"]
 radius = 8.0

--- a/gravitas/scenes/world.gd
+++ b/gravitas/scenes/world.gd
@@ -1,45 +1,5 @@
 extends Node2D
 
-const ANGLE = 90.0
-const ROTATION_DELTA = 3
-var isTurningRight = false
-var isTurningLeft = false
-var rotation_state = 0.0
-
-
 func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed("ui_cancel"):
-
 		get_tree().change_scene_to_file("res://scenes/Main.tscn")
-
-	if isTurningRight:
-		var currentRotation = get_rotation_degrees()
-		var player: CharacterBody2D = get_node("player/Player")
-		if ANGLE > rotation_state:
-			set_rotation_degrees(currentRotation + ROTATION_DELTA)
-			player.set_rotation_degrees(player.rotation_degrees - ROTATION_DELTA)
-			rotation_state += ROTATION_DELTA
-		else:
-			isTurningRight = false
-			rotation_state = 0
-		return
-		
-	if isTurningLeft:
-		var currentRotation = get_rotation_degrees()
-		var player: CharacterBody2D = get_node("player/Player")
-		if ANGLE > rotation_state:
-			set_rotation_degrees(currentRotation - ROTATION_DELTA)
-			player.set_rotation_degrees(player.rotation_degrees + ROTATION_DELTA)
-			rotation_state += ROTATION_DELTA
-		else:
-			isTurningLeft = false
-			rotation_state = 0
-		return
-
-	if Input.is_action_just_pressed("ui_down"):
-		print(get_rotation_degrees())
-		isTurningRight = true
-
-	if Input.is_action_just_pressed("ui_up"):
-		print(get_rotation_degrees())
-		isTurningLeft = true

--- a/gravitas/scenes/world.tscn
+++ b/gravitas/scenes/world.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://scenes/world.gd" id="1_2egk3"]
 [ext_resource type="PackedScene" uid="uid://cat83wdqdyhlq" path="res://scenes/player.tscn" id="1_cd85j"]
-[ext_resource type="Texture2D" uid="uid://c547wu458nbhf" path="res://Assets/Gravitas_assets/CosmicLilac_Tiles.png" id="2_vg6r5"]
+[ext_resource type="Texture2D" uid="uid://tdqtu2i0jasr" path="res://Assets/Gravitas_assets/CosmicLilac_Tiles.png" id="2_vg6r5"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_dpgvs"]
 texture = ExtResource("2_vg6r5")


### PR DESCRIPTION
Added an alternative gravity implementation. To toggle between these two implementations change the `mode` string variable to either "player" or "scene". Note: if the `mode` string is missing or misspelled, the rotation won't work in game.

## Further development

The scene rotation doesn't allow change of direction in the middle of the rotation animation. I think this should implemented and tested in next sprint